### PR TITLE
Fix close() in mock transport

### DIFF
--- a/src/playground/network/testing/mock.py
+++ b/src/playground/network/testing/mock.py
@@ -11,7 +11,7 @@ class MockTransportToProtocol(Transport):
         self.sink.data_received(data)
     def close(self, *args):
         self.closed = True
-        self.sink and self.sink.connection_lost()
+        self.sink and self.sink.connection_lost(None)
         
 class MockTransportToStorageStream(Transport):
     def __init__(self, sinkStream, extra=None):


### PR DESCRIPTION
`connection_lost(exc)` takes one argument which is either an exception object or None.